### PR TITLE
add global tf.FLAGS variable to data.py

### DIFF
--- a/data.py
+++ b/data.py
@@ -5,6 +5,9 @@ import random
 import struct
 import csv
 from tensorflow.core.example import example_pb2
+import tensorflow as tf
+
+FLAGS = tf.app.flags.FLAGS
 
 # <s> and </s> are used in the data files to segment the abstracts into sentences. They don't receive vocab ids.
 SENTENCE_START = '<s>'


### PR DESCRIPTION
FLAGS is undefined in data.py
when running in decode mode and when a term is out of vocabulary, this will cause a NameError
```
  File "pointer-generator/data.py", line 198, in outputids2words
    assert FLAGS.pointer_gen, "Error: model produced a word ID that isn't in the vocabulary"
NameError: global name 'FLAGS' is not defined
```
in
```
    try:
      w = vocab.id2word(i) # might be [UNK]
    except ValueError as e: # w is OOV
      assert FLAGS.pointer_gen, "Error: model produced a word ID that isn't in the vocabulary"
```

This PR adds the global FLAGS variable to data.py