### PR TITLE
Use best model for decoding

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -51,7 +51,7 @@ class BeamSearchDecoder(object):
     self._sess = tf.Session(config=util.get_config())
 
     # Load an initial checkpoint to use for decoding
-    ckpt_path = util.load_ckpt(self._saver, self._sess)
+    ckpt_path = util.load_ckpt(self._saver, self._sess, load_best=True)
 
     if FLAGS.single_pass:
       # Make a descriptive decode directory name

--- a/util.py
+++ b/util.py
@@ -27,12 +27,25 @@ def get_config():
   config.gpu_options.allow_growth=True
   return config
 
-def load_ckpt(saver, sess):
+def load_ckpt(saver, sess, load_best=False):
   """Load checkpoint from the train directory and restore it to saver and sess, waiting 10 secs in the case of failure. Also returns checkpoint name."""
   while True:
     try:
+      ckpt_state = None
+      if load_best:
+        eval_dir = os.path.join(FLAGS.log_root, "eval")
+        tf.logging.info("Trying to load model from: %s" % eval_dir)
+        if os.path.exists(eval_dir):
+          try:
+            ckpt_state = tf.train.get_checkpoint_state(eval_dir, latest_filename="checkpoint_best")
+            tf.logging.info("Loaded best model %s" % ckpt_state.model_checkpoint_path)
+          except ValueError:
+            tf.logging.info("No best model (run eval)")
+      
       train_dir = os.path.join(FLAGS.log_root, "train")
-      ckpt_state = tf.train.get_checkpoint_state(train_dir)
+      if ckpt_state is None:
+        ckpt_state = tf.train.get_checkpoint_state(train_dir)
+
       tf.logging.info('Loading checkpoint %s', ckpt_state.model_checkpoint_path)
       saver.restore(sess, ckpt_state.model_checkpoint_path)
       return ckpt_state.model_checkpoint_path


### PR DESCRIPTION
Hi,

I slightly modified the checkpoint loading so that the decoding first look for a `best_model` in the `eval` directory for the decoding.

This makes more sense to me, you may or may not agree. Also, I could use a flag to enable/disable it. 